### PR TITLE
docs: align French README with English

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Toujours sous `admin`, exécutez ces commandes :
 
 ```sh
 syspatch
+pkg_add mozilla-rootcerts
+mozilla-rootcerts install
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add missing mozilla-rootcerts instructions to the French README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f2708d2c8320bab08f38b4d66f55