### PR TITLE
Add Alpine jail setup script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,5 @@ This folder contains guides for setting up and using the OpenBSD network lab.
 - [Tutoriel Réseau et SSL sur OpenBSD](fr/NETWORK_CHECK_FR.md) - Guide réseau en français.
 - [OpenBSD Networking & SSL Setup Tutorial](en/NETWORK_CHECK_EN.md) - English networking tutorial.
 - [Project Vision](VISION.md) - Long-term project goals.
+- [Utilitaires et scripts – français](fr/README.md) - Notes rapides sur les scripts fournis.
+- [Utilities and scripts – English](en/README.md) - Short documentation for helper scripts.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,0 +1,13 @@
+# Utilities and Scripts
+
+This folder stores additional helpers for the OpenBSD lab.
+
+## Alpine Jail
+
+The `scripts/setup_jail_alpine.sh` script installs Alpine Linux inside a FreeBSD jail. It creates the jail, mounts a package directory and starts the new environment.
+
+Run:
+
+```sh
+doas sh scripts/setup_jail_alpine.sh
+```

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -1,0 +1,13 @@
+# Utilitaires et scripts
+
+Ce dossier contient divers compléments pour le laboratoire OpenBSD.
+
+## Jail Alpine
+
+Le script `scripts/setup_jail_alpine.sh` automatise l'installation d'Alpine Linux dans un jail FreeBSD. Il crée le jail, monte un répertoire de paquets et lance l'environnement prêt à l'emploi.
+
+Exécutez :
+
+```sh
+doas sh scripts/setup_jail_alpine.sh
+```

--- a/scripts/setup_jail_alpine.sh
+++ b/scripts/setup_jail_alpine.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+#
+# Script d'installation d'Alpine Linux dans un jail FreeBSD.
+# Les étapes essentielles sont commentées pour faciliter la compréhension.
+
+set -e
+
+JAIL_NAME="alpine"
+JAIL_ROOT="/usr/jails/${JAIL_NAME}"
+ALPINE_VERSION="3.18"
+ARCH="x86_64"
+TARBALL="alpine-minirootfs-${ALPINE_VERSION}.0-${ARCH}.tar.gz"
+MIRROR="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/releases/${ARCH}/${TARBALL}"
+
+# 1. Création du répertoire du jail
+mkdir -p "$JAIL_ROOT"
+
+# 2. Téléchargement du mini rootfs Alpine
+fetch -o "/tmp/${TARBALL}" "$MIRROR"
+
+# 3. Extraction dans l'arborescence du jail
+mkdir -p "$JAIL_ROOT"
+tar -xzf "/tmp/${TARBALL}" -C "$JAIL_ROOT"
+rm "/tmp/${TARBALL}"
+
+# 4. Copie de la configuration DNS pour permettre les accès réseaux
+cp /etc/resolv.conf "$JAIL_ROOT/etc/"
+
+# 5. Configuration basique du jail
+cat <<EOC > /etc/jail.conf.d/${JAIL_NAME}.conf
+${JAIL_NAME} {
+    path = "${JAIL_ROOT}";
+    host.hostname = "${JAIL_NAME}";
+    mount.devfs;
+    exec.start = "/sbin/init";
+    exec.stop = "/bin/sh /etc/rc.shutdown";
+}
+EOC
+
+# 6. Montage de /dev et du répertoire des paquets (exemple pour /usr/ports/packages)
+mount -t devfs devfs "${JAIL_ROOT}/dev"
+mkdir -p "${JAIL_ROOT}/packages"
+mount -t nullfs /usr/ports/packages "${JAIL_ROOT}/packages" || true
+
+# 7. Lancement du jail
+sysrc jail_enable=YES >/dev/null
+service jail start "${JAIL_NAME}"


### PR DESCRIPTION
## Summary
- script to install Alpine Linux in a FreeBSD jail
- add short docs in French and English
- update documentation index

## Testing
- `sh -n scripts/setup_jail_alpine.sh`
- `shellcheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b4d5bd20832093520ddefdbf813c