### PR TITLE
Fix architecture SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Ce dépôt fournit un environnement OpenBSD prêt à l'emploi pour tester la sé
 - [Tutoriel Réseau & SSL – français](docs/fr/NETWORK_CHECK_FR.md)
 - [Networking & SSL Tutorial – English](docs/en/NETWORK_CHECK_EN.md)
 - [Vision "BSD Stealth Network Lab"](docs/VISION.md)
+- [Architecture Overview](docs/architecture.md)
 
 ## Licence
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,6 @@ This folder contains guides for setting up and using the OpenBSD network lab.
 - [Tutoriel Réseau et SSL sur OpenBSD](fr/NETWORK_CHECK_FR.md) - Guide réseau en français.
 - [OpenBSD Networking & SSL Setup Tutorial](en/NETWORK_CHECK_EN.md) - English networking tutorial.
 - [Project Vision](VISION.md) - Long-term project goals.
+- [Architecture Overview](architecture.md) - How FreeBSD, jails and VMs interact.
 - [Utilitaires et scripts – français](fr/README.md) - Notes rapides sur les scripts fournis.
 - [Utilities and scripts – English](en/README.md) - Short documentation for helper scripts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Overview
+
+This document illustrates how the FreeBSD host interacts with Alpine jails, a bhyve-based Alpine VM running kraftkit and Docker, and an additional DragonFlyBSD VM.
+
+## Components
+
+- **FreeBSD host** – base system that manages bhyve and jails.
+- **Alpine jails** – lightweight containers used for small services.
+- **Alpine VM (bhyve)** – runs kraftkit and Docker for heavier workloads.
+- **DragonFlyBSD VM** – separate environment for testing.
+
+Network traffic can flow between the jails, the virtual machines and the host. The diagram below shows a high-level view of these interactions.
+
+![Architecture diagram](architecture.svg)

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="300" font-family="sans-serif">
+  <rect x="10" y="10" width="300" height="200" fill="#ddeeff" stroke="#000"/>
+  <text x="160" y="30" font-weight="bold" text-anchor="middle">FreeBSD Host</text>
+  <rect x="40" y="60" width="100" height="50" fill="#ffffff" stroke="#000"/>
+  <text x="90" y="90" text-anchor="middle">Alpine jails</text>
+  <rect x="160" y="60" width="130" height="50" fill="#ffffff" stroke="#000"/>
+  <text x="225" y="90" text-anchor="middle">Services</text>
+  <line x1="160" y1="110" x2="160" y2="150" stroke="#000" marker-end="url(#arrow)"/>
+  <rect x="340" y="40" width="150" height="60" fill="#ffeebb" stroke="#000"/>
+  <text x="415" y="70" text-anchor="middle">Alpine VM</text>
+  <text x="415" y="85" text-anchor="middle">(kraftkit &amp; Docker)</text>
+  <rect x="340" y="150" width="150" height="60" fill="#ffeebb" stroke="#000"/>
+  <text x="415" y="180" text-anchor="middle">DragonFlyBSD VM</text>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#000"/>
+    </marker>
+  </defs>
+  <line x1="310" y1="80" x2="340" y2="70" stroke="#000" marker-end="url(#arrow)"/>
+  <line x1="310" y1="140" x2="340" y2="170" stroke="#000" marker-end="url(#arrow)"/>
+</svg>


### PR DESCRIPTION
## Summary
- escape ampersand in architecture.svg
- add XML header so the SVG renders consistently

## Testing
- `sh -n scripts/setup_jail_alpine.sh`


------
https://chatgpt.com/codex/tasks/task_e_6845b7eafff48320b9754564d347a79b